### PR TITLE
Add mobile hamburger menu and fix channel card layout

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -21,9 +21,44 @@ html {
     overflow-y: auto;
 }
 
-.sidebar header h2 {
+.sidebar-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     margin-bottom: 1rem;
+}
+
+.sidebar-header h2 {
     font-size: 1.4rem;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+}
+
+.hamburger-btn {
+    display: none;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0.25rem;
+    width: 2rem;
+    height: 2rem;
+    margin: 0;
+    flex-shrink: 0;
+}
+
+.hamburger-btn span {
+    display: block;
+    width: 20px;
+    height: 2px;
+    background: var(--pico-color);
+    border-radius: 2px;
 }
 
 .sidebar ul {
@@ -630,19 +665,58 @@ fieldset[role="group"] > :last-child:active {
         width: 100%;
         min-width: unset;
         height: auto;
-        position: static;
+        position: sticky;
+        top: 0;
+        z-index: 100;
         border-right: none;
         border-bottom: 1px solid var(--pico-muted-border-color);
+        padding: 0.75rem 1rem;
+        overflow: visible;
+        background: var(--pico-background-color);
+    }
+
+    .sidebar-header {
+        margin-bottom: 0;
+    }
+
+    .hamburger-btn {
+        display: flex;
+    }
+
+    .sidebar-nav {
+        display: none;
+        padding-top: 0.5rem;
+    }
+
+    .sidebar-nav.open {
+        display: flex;
+        flex-direction: column;
     }
 
     .sidebar ul {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.25rem;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        gap: 0;
+    }
+
+    .sidebar footer {
+        padding-top: 0.75rem;
     }
 
     .content {
         padding: 1rem;
+    }
+
+    .channel-card {
+        flex-wrap: wrap;
+    }
+
+    .channel-card .channel-actions {
+        width: 100%;
+        flex: none;
+        margin-top: 0.5rem;
+        padding-top: 0.5rem;
+        border-top: 1px solid var(--pico-muted-border-color);
     }
 
     .channel-edit-form .form-grid {
@@ -652,5 +726,4 @@ fieldset[role="group"] > :last-child:active {
     .video-grid {
         grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
     }
-
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,25 +12,32 @@
 <body hx-boost="true">
     <div class="layout">
         <aside class="sidebar">
-            <header>
-                <h2 style="display:flex;align-items:center;gap:0.5rem;">
+            <div class="sidebar-header">
+                <h2 style="display:flex;align-items:center;gap:0.5rem;margin:0;">
                     <img src="/static/cow-head.png" alt="" style="width:1.5rem;height:1.5rem;object-fit:contain;">
                     CacheCow
                 </h2>
-            </header>
-            <ul>
-                <li><a href="/" {% if active_page == "library" %}class="active"{% endif %}>Library</a></li>
-                <li><a href="/discover" {% if active_page == "discover" %}class="active"{% endif %}>Discover</a></li>
-                <li><a href="/queue" {% if active_page == "queue" %}class="active"{% endif %}>Queue</a></li>
-                <li><a href="/channels" {% if active_page == "channels" %}class="active"{% endif %}>Channels</a></li>
-                <li><a href="/settings" {% if active_page == "settings" %}class="active"{% endif %}>Settings</a></li>
-                <li><a href="/logs" {% if active_page == "logs" %}class="active"{% endif %}>Logs</a></li>
-            </ul>
-            <footer>
-                <form action="/logout" method="post">
-                    <button type="submit" class="outline secondary">Logout</button>
-                </form>
-            </footer>
+                <button class="hamburger-btn" id="hamburger-btn" aria-label="Toggle menu" aria-expanded="false">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </button>
+            </div>
+            <div class="sidebar-nav" id="sidebar-nav">
+                <ul>
+                    <li><a href="/" {% if active_page == "library" %}class="active"{% endif %}>Library</a></li>
+                    <li><a href="/discover" {% if active_page == "discover" %}class="active"{% endif %}>Discover</a></li>
+                    <li><a href="/queue" {% if active_page == "queue" %}class="active"{% endif %}>Queue</a></li>
+                    <li><a href="/channels" {% if active_page == "channels" %}class="active"{% endif %}>Channels</a></li>
+                    <li><a href="/settings" {% if active_page == "settings" %}class="active"{% endif %}>Settings</a></li>
+                    <li><a href="/logs" {% if active_page == "logs" %}class="active"{% endif %}>Logs</a></li>
+                </ul>
+                <footer>
+                    <form action="/logout" method="post">
+                        <button type="submit" class="outline secondary">Logout</button>
+                    </form>
+                </footer>
+            </div>
         </aside>
         <main class="content">
             <div id="toast-container"></div>
@@ -57,6 +64,21 @@
                 if (a) { a.pause(); a.removeAttribute('src'); a.load(); }
             });
         }
+        (function() {
+            var btn = document.getElementById('hamburger-btn');
+            var nav = document.getElementById('sidebar-nav');
+            if (!btn || !nav) return;
+            btn.addEventListener('click', function() {
+                var open = nav.classList.toggle('open');
+                btn.setAttribute('aria-expanded', String(open));
+            });
+            nav.addEventListener('click', function(e) {
+                if (e.target.tagName === 'A') {
+                    nav.classList.remove('open');
+                    btn.setAttribute('aria-expanded', 'false');
+                }
+            });
+        })();
         if (!window._toastReady) {
             window._toastReady = true;
             document.body.addEventListener("showToast", function(evt) {


### PR DESCRIPTION
- Replace full sidebar nav with a hamburger toggle on mobile screens
- Sidebar becomes a sticky top bar; nav items collapse/expand via button
- Fix channel card layout so action buttons wrap below info on narrow viewports instead of overlapping the channel name

https://claude.ai/code/session_01Y8PkP8uw1EmtnvfLkM1bEM