### PR TITLE
Fix silent TikTok downloads (h265/bytevc1 formats lack audio)

### DIFF
--- a/app/services/downloader.py
+++ b/app/services/downloader.py
@@ -336,6 +336,11 @@ def download_channel(channel, settings, session_factory=None, one_off=False, log
 
             if "tiktok" in link.lower():
                 fmt = "bestvideo+bestaudio/best"
+                # TikTok's h265/bytevc1 formats often report acodec=aac in yt-dlp's
+                # format list, but the CDN stream behind them has no actual audio
+                # track — only the h264 formats reliably contain real audio. Without
+                # this, "best" can silently pick a muted h265 stream.
+                format_sort = ["vcodec:h264"]
                 postprocessors = [
                     {"key": "EmbedThumbnail"},
                 ]
@@ -343,6 +348,7 @@ def download_channel(channel, settings, session_factory=None, one_off=False, log
                 pp_hook = None
             else:
                 fmt = "bestvideo[height<=1080][vcodec^=avc1]+bestaudio[acodec^=mp4a]/bestvideo[height<=1080]+bestaudio[acodec^=mp4a]/bestvideo[height<=1080]+bestaudio/best"
+                format_sort = None
                 postprocessors = [
                     {
                         "key": "FFmpegVideoConvertor",
@@ -380,6 +386,8 @@ def download_channel(channel, settings, session_factory=None, one_off=False, log
             }
             if ffmpeg_loc:
                 ydl_opts["ffmpeg_location"] = ffmpeg_loc
+            if format_sort:
+                ydl_opts["format_sort"] = format_sort
 
             with yt_dlp.YoutubeDL(ydl_opts) as ydl:
                 ydl.download([link.strip()])


### PR DESCRIPTION
## Summary
- TikTok's h265 (`bytevc1`) formats report `acodec=aac` in yt-dlp's format metadata, but the actual CDN stream behind them has no audio track — this is a TikTok-side inconsistency, not a yt-dlp bug.
- `download_channel`'s TikTok branch used `format: "bestvideo+bestaudio/best"` with no codec preference, so yt-dlp would sometimes pick the muted h265 variant when it scored as "best quality," producing videos with no audio in Plex.
- Adds `format_sort: ["vcodec:h264"]` for the TikTok branch only, biasing selection toward h264 (which reliably has real audio) without hard-excluding h265 if h264 isn't available for a given video.

## Verification
Reproduced against the live container's yt-dlp/ffmpeg versions:
- Confirmed several already-downloaded TikTok files (e.g. 16/73 for one channel) had video-only streams (HEVC + embedded thumbnail PNG, no audio track) — reproduced the same silent download for one of them using the exact ydl_opts CacheCow uses.
- With the fix, 4 previously-silent videos re-downloaded with proper `aac` audio + `h264` video (including through the `EmbedThumbnail` postprocessor step).
- Re-tested a previously-working (already had audio) video with the fix applied — unaffected, still has audio. No regression.

## Test plan
- [ ] Deploy to a test/staging CacheCow instance and re-download a few TikTok channels that previously produced silent videos, confirm audio in Plex.
- [ ] Watch for a few days across frequently-uploading TikTok channels to confirm no recurrence.