### PR TITLE
Prefix embedded metadata title with channel name

### DIFF
--- a/app/services/downloader.py
+++ b/app/services/downloader.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 import yt_dlp
+from yt_dlp.postprocessor import MetadataParserPP
 
 from app.logging_config import logger
 from app.paths import ARCHIVE_FILE as _ARCHIVE_FILE_PATH
@@ -350,6 +351,22 @@ def download_channel(channel, settings, session_factory=None, one_off=False, log
                 fmt = "bestvideo[height<=1080][vcodec^=avc1]+bestaudio[acodec^=mp4a]/bestvideo[height<=1080]+bestaudio[acodec^=mp4a]/bestvideo[height<=1080]+bestaudio/best"
                 format_sort = None
                 postprocessors = [
+                    # Prefix the embedded metadata title with the channel name so
+                    # media servers show "Mumbo Jumbo - Video title" (matching the
+                    # filename). Sets meta_title, which FFmpegMetadata reads with
+                    # priority over the raw title. Runs pre_process so it's in place
+                    # before FFmpegMetadata embeds it.
+                    {
+                        "key": "MetadataParser",
+                        "when": "pre_process",
+                        "actions": [
+                            (
+                                MetadataParserPP.Actions.INTERPRET,
+                                "%(uploader)s - %(title)s",
+                                "%(meta_title)s",
+                            ),
+                        ],
+                    },
                     {
                         "key": "FFmpegVideoConvertor",
                         "preferedformat": "mp4",


### PR DESCRIPTION
## Summary
Add a MetadataParser post-processor to prefix the embedded video metadata title with the channel/uploader name, ensuring media servers display titles in the format "Channel Name - Video Title" to match the downloaded filename.

## Changes
- Import `MetadataParserPP` from `yt_dlp.postprocessor`
- Add a MetadataParser post-processor that runs in the `pre_process` phase before FFmpeg metadata embedding
- Configure the parser to interpret the pattern `"%(uploader)s - %(title)s"` and store it in the `meta_title` field
- This ensures FFmpegMetadata uses the channel-prefixed title when embedding metadata into the video file

## Implementation Details
- The MetadataParser runs with `"when": "pre_process"` to execute before FFmpegMetadata, ensuring the modified title is available for embedding
- Uses `MetadataParserPP.Actions.INTERPRET` to dynamically construct the title from uploader and original title fields
- The `meta_title` field takes priority over the raw title in FFmpegMetadata, providing consistent display across media servers

https://claude.ai/code/session_012ieULfJJSiUgNwZvZAebCK